### PR TITLE
stm32g0.c: Disable UCPD on boot

### DIFF
--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -145,6 +145,8 @@ bootloader_request(void)
 void
 armcm_main(void)
 {
+    // Disable internal pull-down resistors on UCPDx CCx pins
+    SYSCFG->CFGR1 |= (SYSCFG_CFGR1_UCPD1_STROBE | SYSCFG_CFGR1_UCPD2_STROBE);    
     SCB->VTOR = (uint32_t)VectorTable;
 
     // Reset clock registers (in case bootloader has changed them)


### PR DESCRIPTION
stm32g0.c: Disable UCPD on boot

The UCPD is not used with Katapult but it can result in unexpected behaviour on certain pins due to the internal pull resistors unless disabled.

Signed-off-by: Luke Harrison looxonline@gmail.com