### PR TITLE
stm32: dfu-util "make flash" rules for stm32 mcu

### DIFF
--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -65,6 +65,11 @@ canbus-src-$(CONFIG_HAVE_STM32_CANBUS) += stm32/can.c
 canbus-src-$(CONFIG_HAVE_STM32_FDCANBUS) += stm32/fdcan.c
 src-$(CONFIG_CANSERIAL) += $(canbus-src-y) generic/canbus.c stm32/chipid.c
 
+# Flash rules
+flash: $(OUT)katapult.bin
+	@echo "  Flashing $< to $(FLASH_DEVICE)"
+	$(Q) $(if $(NOSUDO),,sudo) dfu-util -d "$(FLASH_DEVICE)" -R -a 0 -s "$(CONFIG_FLASH_START)":leave -D $(OUT)katapult.bin
+
 # Deployer build
 deployer-y += generic/armcm_boot.c generic/armcm_reset.c $(mcu-y)
 CFLAGS_deployer.elf += -nostdlib -lgcc -lc_nano


### PR DESCRIPTION
In order for users to write `Katapult.bin` to MCU for the first time through DFU (`make flash`), this content was directly copied from Klipper, only the path of `Klipper.bin` was modified to `Katapult.bin`. I noticed that rp2040 has a rule for `make flash` from klipper, so I also copied the rule of STM32 directly.

This PR can be used by the user to directly write `Katapult.bin` to the MCU using the `make flash` command in path "Katapult"