### PR TITLE
stm32/Kconfig: Add option for 32MHz crystals

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -298,11 +298,14 @@ choice
         bool "20 MHz crystal"
     config STM32_CLOCK_REF_25M
         bool "25 MHz crystal"
+    config STM32_CLOCK_REF_32M
+        bool "32 MHz crystal"
     config STM32_CLOCK_REF_INTERNAL
         bool "Internal clock"
 endchoice
 config CLOCK_REF_FREQ
     int
+    default 32000000 if STM32_CLOCK_REF_32M
     default 25000000 if STM32_CLOCK_REF_25M
     default 20000000 if STM32_CLOCK_REF_20M
     default 16000000 if STM32_CLOCK_REF_16M


### PR DESCRIPTION
Certain STM32 Nucleo development boards (eg. F429Zi) come pre-installed with a 32MHz quartz crystal, which is now exposed as an option when selecting STM32 chips.