### PR TITLE
stm32: clear H7 flash status before operations

### DIFF
--- a/src/stm32/flash.c
+++ b/src/stm32/flash.c
@@ -67,6 +67,19 @@ wait_flash(void)
         ;
 }
 
+// Clear status left by a previous STM32H7 erase/program operation
+static void
+clear_flash_status(void)
+{
+#if CONFIG_MACH_STM32H7
+    FLASH->CCR1 = (FLASH_CCR_CLR_EOP | FLASH_CCR_CLR_WRPERR
+                   | FLASH_CCR_CLR_PGSERR | FLASH_CCR_CLR_STRBERR
+                   | FLASH_CCR_CLR_INCERR | FLASH_CCR_CLR_OPERR
+                   | FLASH_CCR_CLR_RDPERR | FLASH_CCR_CLR_RDSERR
+                   | FLASH_CCR_CLR_SNECCERR | FLASH_CCR_CLR_DBECCERR);
+#endif
+}
+
 #ifndef FLASH_KEY1 // Some stm32 headers don't define this
 #define FLASH_KEY1 (0x45670123UL)
 #define FLASH_KEY2 (0xCDEF89ABUL)
@@ -82,6 +95,7 @@ unlock_flash(void)
         FLASH->KEYR = FLASH_KEY2;
     }
     wait_flash();
+    clear_flash_status();
 }
 
 // Place low-level flash hardware into a locked state


### PR DESCRIPTION
## Problem

On an STM32H723, Katapult returned ACK_ERROR on the first SEND_BLOCK at 0x08020000 whenever the 128 KiB application sector already contained firmware. Increasing the host timeout did not change the result. Programming succeeded when the sector was already erased.

## Cause

STM32H7 flash completion and error status flags persist between operations and are cleared through FLASH_CCR1. Katapult waited for the controller to become idle but did not clear those flags before beginning the next operation.

## Fix

Clear the STM32H7 bank 1 completion and error flags during flash unlock. Katapult already performs another lock/unlock between an H7 sector erase and programming, so this also clears the erase status before programming starts.

## Hardware testing

Tested on STM32H723xx with USB communication and a 128 KiB application offset.

- Installed the patched Katapult through STM32 ROM DFU.
- Katapult erased an occupied sector beginning at 0x08020000.
- Wrote and verified a 595-block Klipper image successfully.
- Repeated the update from running Klipper.
- Klipper automatically entered Katapult, and the erase, write, and SHA verification completed successfully without ROM DFU or a manual erase.